### PR TITLE
HelloWorld-with-Modifiers/transferOwnership

### DIFF
--- a/HelloWorld-with-Modifierss
+++ b/HelloWorld-with-Modifierss
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >= 0.7.0 <0.9.0;
+
+contract HelloWorld {
+    string text;
+    address public owner;
+
+    constructor() {
+        text = "Hello World";
+        owner = msg.sender;
+    }
+    modifier onlyOwner(){
+        require(msg.sender == owner, "Caller is not the owner");
+        _;
+
+    }
+    function setText(string calldata _text) public onlyOwner {
+        text = _text;
+
+    }
+
+    function transferOwnership (address newOwner) public onlyOwner {
+        owner = newOwner;
+
+    }
+    function helloWorld() public view returns (string memory) {
+        return text;
+    }
+}


### PR DESCRIPTION
In this part it is stated that;

- "msg.sender" is the owner.  
- "require" is used to limit call access of other people and require that the caller should be the "deployer."
- "modifier" is used to transfer ownership of the contract. After compiling this script on the remix, we can change the account address and pass it as the new owner address in the remix UI using Deployed Contracts part. In that part after deployment, one can see the "functions" of script.